### PR TITLE
Fix "Mods mismatch!" error when overhaul setting is not synced.

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -122,9 +122,7 @@ if data.raw.technology["atomic-bomb"] then
 end
 
 --overhaul
-if settings.startup['overhaul_mode'].value == true then
-    require('scripts/overhaul')
-end
+require('scripts/overhaul')
 
 --white hole
 require('scripts/gravitation/gr_make_white_hole_recipes')

--- a/scripts/overhaul.lua
+++ b/scripts/overhaul.lua
@@ -1,3 +1,6 @@
+if settings.startup['overhaul_mode'].value == true then
+-- indent ignored
+
 local function add_to_recipe(recipe, item, item_amount)
     if not data.raw.recipe[recipe] then
         return
@@ -175,3 +178,5 @@ tech_structure = {"tech", "pre_tech"}
 add_to_recipes(change_table_index(building_table, recipe_structure))
 add_to_recipes(change_table_index(item_table, recipe_structure))
 add_to_techs(change_table_index(tech_table, tech_structure))
+
+end --indent ignored


### PR DESCRIPTION
Conditional "require" context is known as causing that.