### PR TITLE
fix typos

### DIFF
--- a/locale/en/lang_en.cfg
+++ b/locale/en/lang_en.cfg
@@ -649,8 +649,8 @@ fu_burn_oxygen_recipe=Vent oxygen
 fi_refinery_basic_recipe=Highly advanced oil processing
 fi_refinery_coal_recipe=Carbon driven oil processing
 fi_refinery_sulfur_recipe=Sulfur driven oil processing
-fi_refinery_kerosene_recipe=Kerosene seperation
-fi_refinery_kerosene_coal_recipe=Carbon enriched kerosene seperation
+fi_refinery_kerosene_recipe=Kerosene separation
+fi_refinery_kerosene_coal_recipe=Carbon enriched kerosene separation
 
 #booktorio
 [gui]


### PR DESCRIPTION
`kerosene seperation` -> `kerosene separation`.