### PR TITLE
KIX techs fix

### DIFF
--- a/prototypes/electronic/el_ki/el_ki_beacon.lua
+++ b/prototypes/electronic/el_ki/el_ki_beacon.lua
@@ -212,7 +212,7 @@ data:extend({
         },
         energy_usage = '40MW',
         module_specification = {
-            module_slots = 20,
+            module_slots = 18,
             module_info_icon_shift = {0, 0.5},
             module_info_multi_row_initial_height_modifier = -0.3,
         },

--- a/scripts/electronic/el_ki_script.lua
+++ b/scripts/electronic/el_ki_script.lua
@@ -633,9 +633,17 @@ function el_ki_single_beacon_update(id)
                 local coreunit = global.ki.channel[channel].core
                 if global.ki.core[coreunit] then
                     if global.ki.core[coreunit].active then
-                        for i,v in pairs(global.ki.core[coreunit].totalmodules) do
-                            if beacon_inv.can_insert({name=global.ki.core[coreunit].totalmodules[i], count=1}) then
-                                beacon_inv.insert({name=global.ki.core[coreunit].totalmodules[i], count=1})
+                        local moduleset = global.ki.core[coreunit].totalmodules
+                        if beacon_entity.name == 'fu_ki_beacon_entity' then
+                            if game.forces[1].technologies['fu_ki_plus_2_tech'].researched then
+                                moduleset = global.ki.core[coreunit].fu_ki_plus_2_modules
+                            elseif game.forces[1].technologies['fu_ki_plus_1_tech'].researched then
+                                moduleset = global.ki.core[coreunit].fu_ki_plus_1_modules
+                            end
+                        end
+                        for i,v in pairs(moduleset) do
+                            if beacon_inv.can_insert({name=moduleset[i], count=1}) then
+                                beacon_inv.insert({name=moduleset[i], count=1})
                             end
                         end
                     end
@@ -691,6 +699,8 @@ function el_ki_buffer1_adder()
                 
                 local coreid = global.ki.channel[i].core
                 global.ki.core[coreid].totalmodules = {}
+                global.ki.core[coreid].fu_ki_plus_1_modules = {}
+                global.ki.core[coreid].fu_ki_plus_2_modules = {}
                 
                 
                 for x,f in pairs(global.ki.core[coreid].modules) do
@@ -725,7 +735,7 @@ function el_ki_buffer1_adder()
                             table.insert(moduletable, v)
                         end
                     
-                        global.ki.core[coreid].totalmodules = moduletable
+                        global.ki.core[coreid].fu_ki_plus_2_modules = moduletable
                     elseif game.forces[1].technologies['fu_ki_plus_1_tech'].researched then
                         local moduletable = {}
                         for _,v in pairs(global.ki.core[coreid].totalmodules) do 
@@ -733,7 +743,7 @@ function el_ki_buffer1_adder()
                             table.insert(moduletable, v)
                         end
                     
-                        global.ki.core[coreid].totalmodules = moduletable
+                        global.ki.core[coreid].fu_ki_plus_1_modules = moduletable
                     end
                 end
             end


### PR DESCRIPTION
The current behavior of the KIX techs technically affect all beacons despite the descriptions stating that they only affect the KI3 beacons.

This shows up in two cases:

1. the player does not completely fill all three KI cores with modules after researching one or both KIX techs
2. the player uses different types of modules in between the KI cores (various tiers of modules / green + blue modules)

For the first case, the duplicating effect of the KIX technologies would double or triple the global module array that all beacons pull from. So if the player had the KIX1 tech researched and had three modules filled between all three KI cores on the same channel and had a KI2 beacon placed, the beacon would display six modules in total despite the cores only having three. Based on the descriptions of the KIX techs, we would expect this for a KI3 beacon, but not a KI2 one. The KI2 beacon should remain at three modules displayed.

The same applies to the KI1 beacon if the player only has one module in a KI core with either of the KI Plus techs researched. Rather than only showing a single module, it would display two.

For the second case, assume the following setup:
- no KI Plus techs are researched
- a KI1 core targeting channel 1 has a tier-1 blue module and a tier-1 green module in that order
- a KI2 core targeting channel 1 has a tier-2 blue module and a tier-2 green module in that order
- a KI3 core targeting channel 1 has a tier-3 blue module and a tier-3 green module in that order
- a KI2 beacon pointing at channel 1 is placed

With this setup, the KI2 beacon would display one of each of the above modules - tier 1-3 green and tier 1-3 blue for a total of six modules. This I'm assuming is expected behavior, so great. Working as intended.

Now let's say that the player researches the KIX1 tech.

Suddenly the same KI2 beacon now displays two tier-1 green modules, two tier-1 blue modules, and two tier-2 green modules. The tier-2 blue module and both tier-3's have disappeared. Not great for a technology that supposedly doesn't affect KI2 beacons.

It gets worse if the player reasearches the KIX2 tech. Now the same beacon reads three tier-1 greens and three tier-1 blues. The modules in the KI2 and KI3 cores are completely ignored by the KI2 beacon.


With the proposed changes, the global module array-builder script tracks three versions of the module array - one for vanilla, one for the KIX1 tech, and one for the KIX2 tech. The beacon update script applies the correct one to only the KI3 beacons. The KI1 and KI2 beacons will only ever use the vanilla array.

I've tested these changes locally, and they seem to function as I would expect them to. I would appreciate a second set of eyes though.

I also noticed the KI3 beacon prototype has a module size of 20, which seems odd since the total maximum number of modules that can exist in a KI3 beacon is 18, so I changed it to that. I'm unsure if there was a practical reason for having it be 20 though.


Feel free to give feedback or request changes whenever you get time.